### PR TITLE
fix: Correct hyperlink to new example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For Vite apps that have multiple entry points, you can pass the entry point by c
 
 ### Template Registration
 
-You can use custom HTML templates in your Go backend for serving different React pages. See the [`examples/template-registration` directory](https://github.com/olivere/vite/tree/main/examples/template-registration) for an example.
+You can use custom HTML templates in your Go backend for serving different React pages. See the [`examples/template-registry` directory](https://github.com/olivere/vite/tree/main/examples/template-registry) for an example.
 
 ## License
 


### PR DESCRIPTION
Oops! Fix a link I got wrong in the last PR

Hey Oliver, 

I made a small mistake in my previous PR. 

What happened:
I accidentally linked to a non-existent example in the README.

The fix:
I'm updating the link from:
https://github.com/olivere/vite/tree/main/examples/template-registration
to the correct one:
https://github.com/olivere/vite/tree/main/examples/template-registry

Sorry for that.

Let me know if you spot anything else that needs attention.