### PR TITLE
Fix serving public assets for router example prod

### DIFF
--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -21,9 +21,7 @@ var dist embed.FS
 var public embed.FS
 
 func main() {
-	var (
-		isDev = flag.Bool("dev", false, "run in development mode")
-	)
+	isDev := flag.Bool("dev", false, "run in development mode")
 	flag.Parse()
 
 	mux := http.NewServeMux()
@@ -38,7 +36,12 @@ func main() {
 			log.Fatalf("creating sub-filesystem for 'dist' directory: %v", err)
 		}
 		appFS = distFS
-		publicFS = public
+
+		publicSub, err := fs.Sub(public, "public")
+		if err != nil {
+			log.Fatalf("creating sub-filesystem for 'public' directory: %v", err)
+		}
+		publicFS = publicSub
 	}
 
 	// Register the endpoints that get served by the backend.


### PR DESCRIPTION
Router example: the public folder was not loaded properly in production.

### how to reproduce

1. npm install
2. npm run build
3. go run main.go
4. open http://localhost:8080

### found behaviour

vite.svg icon is not loaded/found

### wanted behaviour

vite.svg icon is properly loaded