### PR TITLE
HTMLFragment Dev mode fails if ViteURL is not supplied

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -50,6 +50,11 @@ func HTMLFragment(config Config) (*Fragment, error) {
 	}
 
 	if config.IsDev {
+		// Development mode.
+		if pd.ViteURL == "" {
+			pd.ViteURL = "http://localhost:5173"
+		}
+
 		// Check if the specified Vite template requires a preamble and set the
 		// corresponding preamble string in the plugin configuration.
 		//
@@ -58,14 +63,9 @@ func HTMLFragment(config Config) (*Fragment, error) {
 		// Otherwise, if the template requires a preamble, it uses the
 		// specific preamble for the given Vite template.
 		if config.ViteTemplate < 1 {
-			pd.PluginReactPreamble = template.HTML(React.Preamble(config.ViteURL))
+			pd.PluginReactPreamble = template.HTML(React.Preamble(pd.ViteURL))
 		} else if config.ViteTemplate.RequiresPreamble() {
-			pd.PluginReactPreamble = template.HTML(config.ViteTemplate.Preamble(config.ViteURL))
-		}
-
-		// Development mode.
-		if pd.ViteURL == "" {
-			pd.ViteURL = "http://localhost:5173"
+			pd.PluginReactPreamble = template.HTML(config.ViteTemplate.Preamble(pd.ViteURL))
 		}
 	} else {
 		if config.ViteManifest == "" {


### PR DESCRIPTION
If you do not supply a ViteURL, then the React Preamble does not generate correctly. Specifically, the `@react-refresh` load fails because it generates without a URL host:

```
  import RefreshRuntime from '@react-refresh'
```
instead of
```
  import RefreshRuntime from 'http://localhost:5173/@react-refresh'
```

This causes dev mode to fail to load.

The simplest fix is to load the default onto the `pd` before creating the Preamble.

